### PR TITLE
Add test that demonstrates issue when class based properties are not ordered alphabetically

### DIFF
--- a/Tests/Issues.cs
+++ b/Tests/Issues.cs
@@ -33,5 +33,20 @@ namespace Tests
             Assert.AreEqual("Foo", obj.Property1);
             Assert.AreEqual(string.Empty, obj.ThisBreaksThings);
         }
+
+        private class ThreeTestObject
+        {
+			// The order of these makes a difference.
+            public TwoTestObject BProperty { get; set; }
+            public TwoTestObject AProperty { get; set; }
+        }
+
+        [TestMethod]
+        public void Three()
+        {
+            var bytes = Serializer.Serialize(new ThreeTestObject());
+
+            var obj = Serializer.Deserialize<ThreeTestObject>(bytes);
+        }
     }
 }


### PR DESCRIPTION
Note that if I chance the test class to the following, deserialization works as expected:

``` csharp
private class ThreeTestObject
{
  // The order of these makes a difference.
  public TwoTestObject AProperty { get; set; }
  public TwoTestObject BProperty { get; set; }
}
```

Whereas this does not deserialize properly:

``` csharp
private class ThreeTestObject
{
  // The order of these makes a difference.
  public TwoTestObject BProperty { get; set; }
  public TwoTestObject AProperty { get; set; }
}
```

This is the stack trace:

```
Test method Tests.Issues.Three threw exception: 
System.ArgumentNullException: Value cannot be null.
Parameter name: type
    at System.Reflection.Emit.FieldBuilder..ctor(TypeBuilder typeBuilder, String fieldName, Type type, Type[] requiredCustomModifiers, Type[] optionalCustomModifiers, FieldAttributes attributes)
   at System.Reflection.Emit.TypeBuilder.DefineFieldNoLock(String fieldName, Type type, Type[] requiredCustomModifiers, Type[] optionalCustomModifiers, FieldAttributes attributes)
   at System.Reflection.Emit.TypeBuilder.DefineField(String fieldName, Type type, Type[] requiredCustomModifiers, Type[] optionalCustomModifiers, FieldAttributes attributes)
   at System.Reflection.Emit.TypeBuilder.DefineField(String fieldName, Type type, FieldAttributes attributes)
   at PublicBroadcasting.Impl.ClassTypeDescription.Seal(TypeDescription existing) in Describer.ClassTypeDescription.cs: line 248
   at PublicBroadcasting.Impl.Deserializer.DeserializeCore(Stream stream, ref Type type) in Deserializer.cs: line 65
   at PublicBroadcasting.Impl.Deserializer.Deserialize(Stream stream) in Deserializer.cs: line 19
   at PublicBroadcasting.Serializer.Deserialize(Stream stream) in Serializer.cs: line 626
   at PublicBroadcasting.Serializer.Deserialize(Byte[] bytes) in Serializer.cs: line 609
```
